### PR TITLE
Create simulation environment

### DIFF
--- a/flat_environment.xml
+++ b/flat_environment.xml
@@ -1,0 +1,20 @@
+<mujoco model="flat_environment">
+    <compiler angle="degree" coordinate="local"/>
+    <option timestep="0.01" gravity="0 0 -9.81" iterations="50" integrator="Euler"/>
+    <size nstack="3000" nuser_geom="1"/>
+
+    <worldbody>
+        <geom name="floor" type="plane" pos="0 0 0" size="10 10 0.1" rgba="0.8 0.9 0.8 1"/>
+        <body name="brittle_star" pos="0 0 0.1">
+            <geom type="sphere" size="0.1" rgba="0.2 0.3 0.8 1"/>
+        </body>
+    </worldbody>
+
+    <asset>
+        <texture name="skybox" type="skybox" builtin="gradient" rgb1="0.4 0.6 0.8" rgb2="0.8 0.9 1" width="512" height="512"/>
+    </asset>
+
+    <visual>
+        <map znear="0.01" zfar="50"/>
+    </visual>
+</mujoco>

--- a/simulation_environment.py
+++ b/simulation_environment.py
@@ -1,0 +1,27 @@
+import mujoco_py
+import numpy as np
+
+def create_flat_environment():
+    model = mujoco_py.load_model_from_path("flat_environment.xml")
+    sim = mujoco_py.MjSim(model)
+    return sim
+
+def choose_destination():
+    x = np.random.uniform(-1, 1)
+    y = np.random.uniform(-1, 1)
+    return x, y
+
+def spawn_brittle_star(sim):
+    x = np.random.uniform(-1, 1)
+    y = np.random.uniform(-1, 1)
+    sim.data.qpos[0] = x
+    sim.data.qpos[1] = y
+
+if __name__ == "__main__":
+    sim = create_flat_environment()
+    destination = choose_destination()
+    spawn_brittle_star(sim)
+    viewer = mujoco_py.MjViewer(sim)
+    while True:
+        sim.step()
+        viewer.render()


### PR DESCRIPTION
Related to #1

Add a flat environment in MuJoCo that chooses a destination and spawns a brittle star.

* **simulation_environment.py**
  - Import `mujoco_py` and `numpy` libraries.
  - Define `create_flat_environment` function to initialize the MuJoCo environment.
  - Define `choose_destination` function to randomly select a destination within the environment.
  - Define `spawn_brittle_star` function to place the brittle star at a random position in the environment.
  - Call the functions `create_flat_environment`, `choose_destination`, and `spawn_brittle_star` in the main block.
  - Add a viewer to render the simulation.

* **flat_environment.xml**
  - Define a flat environment in MuJoCo XML format.
  - Include necessary elements such as worldbody, geom, and asset.
  - Set up the environment to be flat and suitable for brittle star simulation.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Bendemeurichy/CurriculumEvolutionBrittleStar/pull/2?shareId=30835a95-3e83-45c7-ba3d-f8515ccbd045).